### PR TITLE
[change]スポット画面のアクセス権限をログイン済みユーザのみに変更

### DIFF
--- a/app/controllers/spots_controller.rb
+++ b/app/controllers/spots_controller.rb
@@ -1,4 +1,5 @@
 class SpotsController < ApplicationController
+  before_action :authenticate_user!
   MAX_SLIDER_IMAGE_NUM_FOR_SHOW = 7
   MAX_SLIDER_IMAGE_NUM_FOR_INDEX = 3
   MAX_SEARCH_SPOT_NUM = 100


### PR DESCRIPTION
ログインしていないユーザーがスポット詳細画面とスポット一覧画面にアクセスしたとき、
ログイン画面にリダイレクトされるように仕様を変更しました。